### PR TITLE
Bindings fix for WIN32 OS

### DIFF
--- a/src/node-svm/node-svm.cc
+++ b/src/node-svm/node-svm.cc
@@ -22,7 +22,12 @@ NAN_METHOD(NodeSvm::New) {
     else {
         // Invoked as plain function `MyObject(...)`, turn into construct call.
         const int argc = 0;
-        Local<Value> argv[argc] = {  };
+#ifdef _WIN32
+    // On windows you get "error C2466: cannot allocate an array of constant size 0" and we use a pointer
+    Local<Value>* argv;
+#else
+    Local<Value> argv[argc];
+#endif
         return scope.Close(constructor->NewInstance(argc, argv));
     }
 }

--- a/src/node-svm/training-worker.h
+++ b/src/node-svm/training-worker.h
@@ -28,7 +28,13 @@ class TrainingWorker : public NanAsyncWorker {
   void HandleOKCallback () {
     NanScope();
 
-    Local<Value> argv[] = {};
+	#ifdef _WIN32
+    // On windows you get "error C2466: cannot allocate an array of constant size 0" and we use a pointer
+    Local<Value>* argv;
+#else
+    Local<Value> argv[0];
+#endif
+
 
     callback->Call(0, argv);
   };


### PR DESCRIPTION
WIN32 Fix to avoid error C2466 due to array dafinitions equal to 0  like:

```
Local<Value> argv[] = {};
```
Based on https://github.com/samshull/node-proxy/blob/master/src/node-proxy.cc solution