### PR TITLE
Fixed include in header of nan for npm@3

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,9 @@
         './src/addon.cc',
         './src/node-svm/node-svm.cc'
       ],
+      "include_dirs" : [
+        "<!(node -e \"require('nan')\")"
+      ],
       'cflags': ['-Wall', '-O3', '-fPIC', '-c'],
       "cflags_cc!": ["-fno-rtti", "-fno-exceptions"]
     }

--- a/src/node-svm/node-svm.h
+++ b/src/node-svm/node-svm.h
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <node.h>
 #include <assert.h>
-#include "../../node_modules/nan/nan.h"
+#include <nan.h>
 #include "../libsvm/svm.h"
 
 


### PR DESCRIPTION
With npm@3, dependencies are stored maximally flat, which results in `nan` not being nested inside of the `node-svm` folder. This breaks compilation.

The problem was fixed by adding the `nan` folder to the `binding.gyp` file as an include, as described by `nan`'s authors.